### PR TITLE
doc: update external references to base branch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ In particular, the orchestration should at least be done via docker-compose, the
 
 
 ### Frontend
-For a visual overview, see the `User Interface` section ["User Interface" section in the system design documentation.](https://github.com/YoinkBird/cyclesafe/blob/master/docs/report/report.md#user-application).
+For a visual overview, see the `User Interface` section ["User Interface" section in the system design documentation.](https://github.com/YoinkBird/cyclesafe/blob/613f6dcc4a95d4394546f2ba83d20263461a02b4/docs/report/report.md).
 
 [./directions.html](./directions.html)
 * rudimentary webpage using Vanilla JS to implement google maps API

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ In particular, the orchestration should at least be done via docker-compose, the
 
 
 ### Frontend
-For a visual overview, see the `User Interface` section ["User Interface" section in the system design documentation.](https://github.com/YoinkBird/cyclesafe/blob/613f6dcc4a95d4394546f2ba83d20263461a02b4/docs/report/report.md).
+For a visual overview, see the `User Interface` section ["User Interface" section in the system design documentation.](https://github.com/YoinkBird/cyclesafe/blob/613f6dcc4a95d4394546f2ba83d20263461a02b4/docs/report/report.md#user-application).
 
 [./directions.html](./directions.html)
 * rudimentary webpage using Vanilla JS to implement google maps API

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Cycle Safe Server and UI for Model Generation
 
 Server, UI, Test Framework, and Orchestration for the 
- [Probabilistic Routing-Based Injury Avoidance Navigation Framework for Pedalcyclists](https://github.com/YoinkBird/cyclesafe/blob/master/docs/report/report.md) Project.
+ [Probabilistic Routing-Based Injury Avoidance Navigation Framework for Pedalcyclists](https://github.com/YoinkBird/cyclesafe/blob/613f6dcc4a95d4394546f2ba83d20263461a02b4/docs/report/report.md) Project.
 
 This repo contains the navigation frontend, scoring server, and orchestration to run and validate the navigation framework.
 
@@ -17,7 +17,7 @@ Clone this repo.
 
 # Architecture
 
-The frontend and backend interactions are documented in the [Architecture overview documentation](https://github.com/YoinkBird/cyclesafe/blob/master/docs/report/report.md#architecture), where the [Data Formats and Modeling Application](https://github.com/YoinkBird/cyclesafe/blob/master/docs/report/report.md#data-formats) are managed by the 
+The frontend and backend interactions are documented in the [Architecture overview documentation](https://github.com/YoinkBird/cyclesafe/blob/613f6dcc4a95d4394546f2ba83d20263461a02b4/docs/report/report.md#architecture), where the [Data Formats and Modeling Application](https://github.com/YoinkBird/cyclesafe/blob/613f6dcc4a95d4394546f2ba83d20263461a02b4/docs/report/report.md#data-formats) are managed by the 
 [Model Generation Repo](https://github.com/YoinkBird/cyclesafe).
 
 # Contributing

--- a/setup.sh
+++ b/setup.sh
@@ -67,7 +67,7 @@ fi
 # fi
 
 modelgendir="modelgen";
-modelgenbranch="master";
+modelgenbranch="main";
 # check whether modelgen repo exists, clone as needed unless during the cleanup steps (clean and reset)
 if [ ! -e "${modelgendir}/.git/config" ] && [ ${step} != "clean" ] && [ ${step} != "reset" ] ; then
   # get the host of the repo


### PR DESCRIPTION
Depends on https://github.com/YoinkBird/cyclesafe/issues/11

Locate and update link targets:
1. `$ grep -l --exclude-dir .git -rns master . | xargs nvim -o`
2a. Docs: convert to permalink: `:%s/<old base branch name>/<sha>/gc`
2b. Code: convert to new branch name `:%s/<old base branch name>/main/gc`